### PR TITLE
Add playbook to monitor fail2ban current number of banned IPs

### DIFF
--- a/Ansible-Playbooks/fail2ban-monitoring.yml
+++ b/Ansible-Playbooks/fail2ban-monitoring.yml
@@ -1,0 +1,5 @@
+---
+- name: "Check the current number of banned IPs via fail2ban"
+  hosts: all
+  roles:
+    - role: "fail2ban-monitoring"

--- a/Ansible-Playbooks/roles/fail2ban-monitoring/README.md
+++ b/Ansible-Playbooks/roles/fail2ban-monitoring/README.md
@@ -1,0 +1,2 @@
+Fail2Ban Monitoring
+=========

--- a/Ansible-Playbooks/roles/fail2ban-monitoring/defaults/main.yml
+++ b/Ansible-Playbooks/roles/fail2ban-monitoring/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for fail2ban-monitoring

--- a/Ansible-Playbooks/roles/fail2ban-monitoring/handlers/main.yml
+++ b/Ansible-Playbooks/roles/fail2ban-monitoring/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for fail2ban-monitoring

--- a/Ansible-Playbooks/roles/fail2ban-monitoring/meta/main.yml
+++ b/Ansible-Playbooks/roles/fail2ban-monitoring/meta/main.yml
@@ -1,0 +1,52 @@
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.1
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/Ansible-Playbooks/roles/fail2ban-monitoring/tasks/main.yml
+++ b/Ansible-Playbooks/roles/fail2ban-monitoring/tasks/main.yml
@@ -13,4 +13,4 @@
   ansible.builtin.debug:
     msg: "{{ banned_num.stdout_lines }}"
   when: banned_num.stdout_lines
-  failed_when: banned_num.stdout != "0" 
+  failed_when: banned_num.stdout != "0"

--- a/Ansible-Playbooks/roles/fail2ban-monitoring/tasks/main.yml
+++ b/Ansible-Playbooks/roles/fail2ban-monitoring/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+# tasks file for fail2ban-monitoring
+
+# Check the current number of banned IPs via the fail2ban-monitoring script (home-made script: https://github.com/Antiz96/Linux-Server/blob/main/Services/Fail2Ban.md#tips-and-tricks)
+- name: Check number of banned IPs
+  ansible.builtin.shell:
+    cmd: fail2ban-monitoring
+  register: banned_num
+  changed_when: banned_num.rc == 0
+
+# Display the number of currently banned IPs
+- name: Display number of banned IPs
+  ansible.builtin.debug:
+    msg: "{{ banned_num.stdout_lines }}"
+  when: banned_num.stdout_lines
+  failed_when: banned_num.stdout != "0" 

--- a/Ansible-Playbooks/roles/fail2ban-monitoring/tests/inventory
+++ b/Ansible-Playbooks/roles/fail2ban-monitoring/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/Ansible-Playbooks/roles/fail2ban-monitoring/tests/test.yml
+++ b/Ansible-Playbooks/roles/fail2ban-monitoring/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - fail2ban-monitoring

--- a/Ansible-Playbooks/roles/fail2ban-monitoring/vars/main.yml
+++ b/Ansible-Playbooks/roles/fail2ban-monitoring/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for fail2ban-monitoring


### PR DESCRIPTION
While waiting for a good enough way to create a Zabbix proxy (from a network POV), I'll use this playbook to monitor the number of currently banned IPs via fail2ban on VPS