### PR TITLE
Add a pause + manual confirmation between the two physical servers update

### DIFF
--- a/Dotfiles/Services/Jenkins_Pipeline_Update_Infra.groovy
+++ b/Dotfiles/Services/Jenkins_Pipeline_Update_Infra.groovy
@@ -156,6 +156,7 @@ pipeline {
                     if (result == 'FAILURE') {
                         error("Update Servers - Proxmox - Prod - Pmx02 failed. Aborting pipeline.")
                     }
+		    input("Proceed with Update Servers - Proxmox - Prod - Pmx01?")
                 }
             }
         }


### PR DESCRIPTION
This commit aims to add a pause between the update of the two physical servers, waiting for a manual confirmation to continue. Since physical servers are a bit more complicated to 'rollback' than virtual ones (in case of post update problems for instance), adding a pause between those two steps allows to verify that the first physical server is okay before proceeding to update the second one.