### PR TITLE
Increase ESP size to 1G

### DIFF
--- a/Services/Debian.md
+++ b/Services/Debian.md
@@ -13,7 +13,7 @@ I do not select anything during the installation process (no DE, no standard or 
 
 **System Disk:**  
 
-- ESP   --> 550 MB
+- ESP   --> 1G
 - Swap  --> 4 GB
 - /     --> 25 GB (0% reserved block) - ext4
 - /data --> Left free space (0% reserved block) - ext4

--- a/VMs/Arch-Linux_Server_Template.md
+++ b/VMs/Arch-Linux_Server_Template.md
@@ -20,13 +20,13 @@ Replaces: <https://github.com/Antiz96/Linux-Configuration/blob/main/Arch-Linux/B
 
 - Personal context:
 
-> EFI partition mounted on /boot/EFI --> 550M - ESP  
+> EFI partition mounted on /boot/EFI --> 1G - ESP  
 > Swap partition --> 4G - SWAP  
 > Root partition mounted on / --> Left free space - EXT4
 
 - Professional context:
 
-> EFI partition mounted on /boot --> 550M - FAT32  
+> EFI partition mounted on /boot --> 1G - FAT32  
 > Swap partition --> 4G - SWAP  
 > Root partition --> Left free space - XFS - LVM  
 > > / --> 3G  

--- a/VMs/BlackArch.md
+++ b/VMs/BlackArch.md
@@ -8,7 +8,7 @@ Just a quick reminder on how I install BlackArch to practice security stuff.
 
 ### Partition scheme
 
-> 550M EFI  
+> 1G EFI  
 > 4G Swap  
 > Left ext4 root
 

--- a/VMs/Debian_Server_Template.md
+++ b/VMs/Debian_Server_Template.md
@@ -17,13 +17,13 @@ I basically follow each installation steps normally with the following exception
 
 - Personal context:
 
-> EFI partition mounted on /boot/EFI --> 550M - ESP  
+> EFI partition mounted on /boot/EFI --> 1G - ESP  
 > Swap partition --> 4G - SWAP  
 > Root partition mounted on / --> Left free space - EXT4 (0% Reserved block)
 
 - Professional context:
 
-> EFI partition mounted on /boot --> 550M - ESP  
+> EFI partition mounted on /boot --> 1G - ESP  
 > Swap partition --> 4G - SWAP  
 > Root partition --> Left free space - XFS - LVM  
 > > / --> 3G  

--- a/VMs/Gentoo_Server_Template.md
+++ b/VMs/Gentoo_Server_Template.md
@@ -19,13 +19,13 @@ Replaces the fdisk part in: <https://github.com/Antiz96/Linux-Configuration/blob
 
 - Personal context:
 
-> EFI partition mounted on /boot/EFI --> 550M - ESP  
+> EFI partition mounted on /boot/EFI --> 1G - ESP  
 > Swap partition --> 4G - SWAP  
 > Root partition mounted on / --> Left free space - EXT4 (0% Reserved block)
 
 - Professional context:
 
-> EFI partition mounted on /boot --> 550M - FAT32  
+> EFI partition mounted on /boot --> 1G - FAT32  
 > Swap partition --> 4G - SWAP  
 > Root partition --> Left free space - XFS - LVM  
 > > / --> 3G  

--- a/VMs/RHEL_Server_Template.md
+++ b/VMs/RHEL_Server_Template.md
@@ -17,13 +17,13 @@ I basically follow each installation steps normally with the following exception
 
 - Personal context:
 
-> EFI partition mounted on /boot/EFI --> 550M - ESP  
+> EFI partition mounted on /boot/EFI --> 1G - ESP  
 > Swap partition --> 4G - SWAP  
 > Root partition mounted on / --> Left free space - EXT4 (0% Reserved block)
 
 - Professional context:
 
-> EFI partition mounted on /boot --> 550M - ESP  
+> EFI partition mounted on /boot --> 1G - ESP  
 > Swap partition --> 4G - SWAP  
 > Root partition --> Left free space - XFS - LVM  
 > > / --> 3G  

--- a/VMs/Ubuntu_Server_Template.md
+++ b/VMs/Ubuntu_Server_Template.md
@@ -17,13 +17,13 @@ I basically follow each installation steps normally with the following exception
 
 - Personal context:
 
-> EFI partition mounted on /boot/EFI --> 550M - ESP  
+> EFI partition mounted on /boot/EFI --> 1G - ESP  
 > Swap partition --> 4G - SWAP  
 > Root partition mounted on / --> Left free space - EXT4 (0% Reserved block)
 
 - Professional context:
 
-> EFI partition mounted on /boot --> 550M - ESP  
+> EFI partition mounted on /boot --> 1G - ESP  
 > Swap partition --> 4G - SWAP  
 > Root partition --> Left free space - XFS - LVM  
 > > / --> 3G  


### PR DESCRIPTION
Nowadays, there's no point keeping the ESP small (in terms of size). With disk space non being a constraint anymore, it's just a potential risk to expose yourself to problems in case of eventual bugs (e.g. https://gitlab.archlinux.org/archlinux/mkinitcpio/mkinitcpio/-/issues/238) or simply because things gets bigger with time.

Switching to a 1G ESP doesn't represente a hugo cost and is safer