### PR TITLE
Update nginx config

### DIFF
--- a/Services/Nginx.md
+++ b/Services/Nginx.md
@@ -64,7 +64,8 @@ sudo vim "URL".conf
 ```text
 server {
 
-    listen clprd01.rc:443 ssl http2;
+    listen clprd01.rc:443 ssl 
+    http2 on;
     server_name “URL”;
 
     # Log Path

--- a/Services/Nginx.md
+++ b/Services/Nginx.md
@@ -64,7 +64,7 @@ sudo vim "URL".conf
 ```text
 server {
 
-    listen clprd01.rc:443 ssl 
+    listen clprd01.rc:443 ssl;
     http2 on;
     server_name “URL”;
 


### PR DESCRIPTION
Since nginx 1.25.1:

`nginx: [warn] the "listen ... http2" directive is deprecated, use the "http2" directive instead`