### PR TITLE
 Add fastfetch to servers packages

### DIFF
--- a/Services/Debian.md
+++ b/Services/Debian.md
@@ -51,7 +51,7 @@ sudo systemctl restart networking
 
 ```bash
 sudo apt update && sudo apt full-upgrade
-sudo apt install vim man bash-completion openssh-server dnsutils traceroute rsync zip unzip diffutils firewalld mlocate htop curl openssl telnet chrony parted wget logrotate
+sudo apt install vim man bash-completion openssh-server dnsutils traceroute rsync zip unzip diffutils firewalld mlocate htop curl openssl telnet chrony wget logrotate fail2ban python3-passlib fastfetch
 sudo systemctl enable --now logrotate.timer
 ```
 
@@ -127,6 +127,10 @@ sudo firewall-cmd --remove-service="ssh" --permanent #Close the default SSH port
 sudo firewall-cmd --remove-service="dhcpv6-client" --permanent #Close the dhcpv6-client port as I don't use it
 sudo firewall-cmd --reload
 ```
+
+## Configure and start fail2ban
+
+Procedure: <https://github.com/Antiz96/Linux-Server/blob/main/Services/Fail2Ban.md>
 
 ## Enable fstrim (for SSDs only - optional)
 

--- a/VMs/Alpine-Linux_Server_Template.md
+++ b/VMs/Alpine-Linux_Server_Template.md
@@ -45,7 +45,7 @@ apk update && apk upgrade
 ### Install useful packages
 
 ```bash
-apk add vim man-db sudo bash bash-completion openssh openssh-server-pam inetutils-telnet bind-tools wget traceroute rsync zip unzip diffutils mlocate htop curl logrotate fail2ban fstrim chrony firewalld shadow py3-passlib
+apk add vim man-db sudo bash bash-completion openssh openssh-server-pam inetutils-telnet bind-tools wget traceroute rsync zip unzip diffutils mlocate htop curl logrotate fail2ban fstrim chrony firewalld shadow py3-passlib fastfetch
 ```
 
 ### Configure various things

--- a/VMs/Arch-Linux_Server_Template.md
+++ b/VMs/Arch-Linux_Server_Template.md
@@ -36,7 +36,7 @@ Replaces: <https://github.com/Antiz96/Linux-Configuration/blob/main/Arch-Linux/B
 Replaces: <https://github.com/Antiz96/Linux-Configuration/blob/main/Arch-Linux/Base_installation.md#log-in-with-the-regular-user-previously-created-and-install-additional-useful-packages>
 
 ```bash
-pacman -S man bash-completion openssh inetutils dnsutils wget traceroute rsync zip unzip diffutils mlocate htop logrotate pacman-contrib fail2ban python-passlib
+pacman -S man bash-completion openssh inetutils dnsutils wget traceroute rsync zip unzip diffutils mlocate htop logrotate pacman-contrib fail2ban python-passlib fastfetch
 ```
 
 ### Configure various things

--- a/VMs/Debian_Server_Template.md
+++ b/VMs/Debian_Server_Template.md
@@ -31,7 +31,7 @@ I basically follow each installation steps normally with the following exception
 ### Install useful packages
 
 ```bash
-apt update && apt install sudo vim man bash-completion openssh-server dnsutils traceroute rsync zip unzip diffutils firewalld mlocate htop curl openssl telnet chrony wget logrotate fail2ban python3-passlib
+apt update && apt install sudo vim man bash-completion openssh-server dnsutils traceroute rsync zip unzip diffutils firewalld mlocate htop curl openssl telnet chrony wget logrotate fail2ban python3-passlib fastfetch
 ```
 
 ### Configure various things

--- a/VMs/Gentoo_Server_Template.md
+++ b/VMs/Gentoo_Server_Template.md
@@ -35,7 +35,7 @@ Replaces the fdisk part in: <https://github.com/Antiz96/Linux-Configuration/blob
 Replaces: <https://github.com/Antiz96/Linux-Configuration/blob/main/Gentoo/Base_installation.md#install-additional-useful-packages>
 
 ```bash
-emerge -a bash-completion openssh ssh netkit-telnetd bind-tools wget traceroute rsync zip unzip cronie diffutils mlocate htop logrotate fail2ban passlib
+emerge -a bash-completion openssh ssh netkit-telnetd bind-tools wget traceroute rsync zip unzip cronie diffutils mlocate htop logrotate fail2ban passlib fastfetch
 ```
 
 ### Configure various things

--- a/VMs/RHEL_Server_Template.md
+++ b/VMs/RHEL_Server_Template.md
@@ -31,7 +31,7 @@ I basically follow each installation steps normally with the following exception
 ### Install useful packages
 
 ```bash
-dnf update && dnf install sudo vim man bash-completion openssh-server bind-utils traceroute rsync zip unzip diffutils firewalld mlocate curl openssl telnet chrony wget fail2ban epel-release && dnf install htop logrotate python3-passlib
+dnf update && dnf install sudo vim man bash-completion openssh-server bind-utils traceroute rsync zip unzip diffutils firewalld mlocate curl openssl telnet chrony wget fail2ban epel-release && dnf install htop logrotate python3-passlib fastfetch
 ```
 
 ### Configure various things

--- a/VMs/Ubuntu_Server_Template.md
+++ b/VMs/Ubuntu_Server_Template.md
@@ -31,7 +31,7 @@ I basically follow each installation steps normally with the following exception
 ### Install useful packages
 
 ```bash
-apt update && apt install sudo vim man bash-completion openssh-server dnsutils traceroute rsync zip unzip diffutils firewalld mlocate htop curl openssl telnet chrony wget logrotate fail2ban python3-passlib
+apt update && apt install sudo vim man bash-completion openssh-server dnsutils traceroute rsync zip unzip diffutils firewalld mlocate htop curl openssl telnet chrony wget logrotate fail2ban python3-passlib fastfetch
 ```
 
 ### Configure various things


### PR DESCRIPTION
While neofetch was mostly a "fun" tool, fastfetch reached a level of customization and additional system information to the point where I feel like it's actually useful to also have it on servers.

Indeed, in addition of the usual information like the running kernel, system uptime and so on... fastfetch can also show the CPU temp, the locale, the ip addresse(s), disk space of mount points, etc... It's a nice way to wrap a lot of useful information into a single command.

I added fastfetch in Debian/Ubuntu procedure despite the fact it is not available yet in the repos but I guess [it should land there soon-ish](https://salsa.debian.org/debian/fastfetch).