### PR TITLE
Exclude the 2.7.x development branch from the nvchecker checks

### DIFF
--- a/Dotfiles/Services/nvchecker.toml
+++ b/Dotfiles/Services/nvchecker.toml
@@ -903,7 +903,7 @@ host = "gitlab.isc.org"
 gitlab = "isc-projects/kea"
 prefix = "Kea-"
 use_max_tag = true
-#exclude_regex = ".*(pre|a|alpha|b|beta|r|rc).*"
+exclude_regex = ".*Kea-2.7.*"
 
 [libdisplay-info]
 source = "gitlab"


### PR DESCRIPTION
Addresses https://gitlab.archlinux.org/archlinux/packaging/packages/kea/-/issues/2