### PR TITLE
Replace mlocate with plocate

### DIFF
--- a/Services/Debian.md
+++ b/Services/Debian.md
@@ -51,7 +51,7 @@ sudo systemctl restart networking
 
 ```bash
 sudo apt update && sudo apt full-upgrade
-sudo apt install vim man bash-completion openssh-server dnsutils traceroute rsync zip unzip diffutils firewalld mlocate htop curl openssl telnet chrony wget logrotate fail2ban python3-passlib fastfetch
+sudo apt install vim man bash-completion openssh-server dnsutils traceroute rsync zip unzip diffutils firewalld plocate htop curl openssl telnet chrony wget logrotate fail2ban python3-passlib fastfetch
 sudo systemctl enable --now logrotate.timer
 ```
 

--- a/VMs/Alpine-Linux_Server_Template.md
+++ b/VMs/Alpine-Linux_Server_Template.md
@@ -45,7 +45,7 @@ apk update && apk upgrade
 ### Install useful packages
 
 ```bash
-apk add vim man-db sudo bash bash-completion openssh openssh-server-pam inetutils-telnet bind-tools wget traceroute rsync zip unzip diffutils mlocate htop curl logrotate fail2ban fstrim chrony firewalld shadow py3-passlib fastfetch
+apk add vim man-db sudo bash bash-completion openssh openssh-server-pam inetutils-telnet bind-tools wget traceroute rsync zip unzip diffutils plocate htop curl logrotate fail2ban fstrim chrony firewalld shadow py3-passlib fastfetch
 ```
 
 ### Configure various things

--- a/VMs/Arch-Linux_Server_Template.md
+++ b/VMs/Arch-Linux_Server_Template.md
@@ -36,7 +36,7 @@ Replaces: <https://github.com/Antiz96/Linux-Configuration/blob/main/Arch-Linux/B
 Replaces: <https://github.com/Antiz96/Linux-Configuration/blob/main/Arch-Linux/Base_installation.md#log-in-with-the-regular-user-previously-created-and-install-additional-useful-packages>
 
 ```bash
-pacman -S man bash-completion openssh inetutils dnsutils wget traceroute rsync zip unzip diffutils mlocate htop logrotate pacman-contrib fail2ban python-passlib fastfetch
+pacman -S man bash-completion openssh inetutils dnsutils wget traceroute rsync zip unzip diffutils plocate htop logrotate pacman-contrib fail2ban python-passlib fastfetch
 ```
 
 ### Configure various things

--- a/VMs/Debian_Server_Template.md
+++ b/VMs/Debian_Server_Template.md
@@ -31,7 +31,7 @@ I basically follow each installation steps normally with the following exception
 ### Install useful packages
 
 ```bash
-apt update && apt install sudo vim man bash-completion openssh-server dnsutils traceroute rsync zip unzip diffutils firewalld mlocate htop curl openssl telnet chrony wget logrotate fail2ban python3-passlib fastfetch
+apt update && apt install sudo vim man bash-completion openssh-server dnsutils traceroute rsync zip unzip diffutils firewalld plocate htop curl openssl telnet chrony wget logrotate fail2ban python3-passlib fastfetch
 ```
 
 ### Configure various things

--- a/VMs/Gentoo_Server_Template.md
+++ b/VMs/Gentoo_Server_Template.md
@@ -35,7 +35,7 @@ Replaces the fdisk part in: <https://github.com/Antiz96/Linux-Configuration/blob
 Replaces: <https://github.com/Antiz96/Linux-Configuration/blob/main/Gentoo/Base_installation.md#install-additional-useful-packages>
 
 ```bash
-emerge -a bash-completion openssh ssh netkit-telnetd bind-tools wget traceroute rsync zip unzip cronie diffutils mlocate htop logrotate fail2ban passlib fastfetch
+emerge -a bash-completion openssh ssh netkit-telnetd bind-tools wget traceroute rsync zip unzip cronie diffutils plocate htop logrotate fail2ban passlib fastfetch
 ```
 
 ### Configure various things

--- a/VMs/RHEL_Server_Template.md
+++ b/VMs/RHEL_Server_Template.md
@@ -31,7 +31,7 @@ I basically follow each installation steps normally with the following exception
 ### Install useful packages
 
 ```bash
-dnf update && dnf install sudo vim man bash-completion openssh-server bind-utils traceroute rsync zip unzip diffutils firewalld mlocate curl openssl telnet chrony wget fail2ban epel-release && dnf install htop logrotate python3-passlib fastfetch
+dnf update && dnf install sudo vim man bash-completion openssh-server bind-utils traceroute rsync zip unzip diffutils firewalld plocate curl openssl telnet chrony wget fail2ban epel-release && dnf install htop logrotate python3-passlib fastfetch
 ```
 
 ### Configure various things

--- a/VMs/Ubuntu_Server_Template.md
+++ b/VMs/Ubuntu_Server_Template.md
@@ -31,7 +31,7 @@ I basically follow each installation steps normally with the following exception
 ### Install useful packages
 
 ```bash
-apt update && apt install sudo vim man bash-completion openssh-server dnsutils traceroute rsync zip unzip diffutils firewalld mlocate htop curl openssl telnet chrony wget logrotate fail2ban python3-passlib fastfetch
+apt update && apt install sudo vim man bash-completion openssh-server dnsutils traceroute rsync zip unzip diffutils firewalld plocate htop curl openssl telnet chrony wget logrotate fail2ban python3-passlib fastfetch
 ```
 
 ### Configure various things


### PR DESCRIPTION
mlocate is very much an abandoned project, while plocate is a modern implementation with a faster database implementation along with io_uring support.

See https://lists.archlinux.org/archives/list/arch-dev-public@lists.archlinux.org/thread/6Q2OBF3VPAWII66UIA43OEZFSRGUWS4E/