### PR TITLE
Use latest releases for protonmail-bridge in nvchecker config

### DIFF
--- a/Dotfiles/Services/nvchecker.toml
+++ b/Dotfiles/Services/nvchecker.toml
@@ -667,7 +667,7 @@ exclude_regex = ".*(pre|a|alpha|b|beta|r|rc).*"
 source = "github"
 github = "ProtonMail/proton-bridge"
 prefix = "v"
-use_max_tag = true
+use_latest_release = true
 exclude_regex = ".*(pre|a|alpha|b|beta|r|rc).*"
 
 [pychess]


### PR DESCRIPTION
So 'pre-releases' are filtered out