### PR TITLE
Remove xfce4-embed-plugin from nvchecker

### DIFF
--- a/Dotfiles/Services/nvchecker.toml
+++ b/Dotfiles/Services/nvchecker.toml
@@ -1399,13 +1399,6 @@ prefix = "xfce4-diskperf-plugin-"
 use_max_tag = true
 exclude_regex = "2.*|v.*"
 
-[xfce4-embed-plugin]
-source = "gitlab"
-host = "gitlab.xfce.org"
-gitlab = "panel-plugins/xfce4-embed-plugin"
-prefix = "xfce4-embed-plugin-"
-use_max_tag = true
-
 [xfce4-eyes-plugin]
 source = "gitlab"
 host = "gitlab.xfce.org"


### PR DESCRIPTION
Requires outdated lib to be built, I won't move & maintain this package after all.
See https://lists.archlinux.org/archives/list/aur-requests@lists.archlinux.org/thread/7ZE2GY525JJGLYV2MZZ2Z7M7N7WOAPBS/