### PR TITLE
Fix Spotify's nvchecker conf

### DIFF
--- a/Dotfiles/Services/nvchecker.toml
+++ b/Dotfiles/Services/nvchecker.toml
@@ -2070,7 +2070,7 @@ url = "https://high5.nl/mirrors/postfix-release/official/"
 
 [spotify]
 source = "apt"
-mirror = "http://repository.spotify.com/"
+mirror = "http://repository.spotify.com"
 pkg = "spotify-client"
 suite = "testing"
 repo = "non-free"


### PR DESCRIPTION
Since a few days, nvchecker reports the following error for Spotify:

```
[E 02-13 08:46:29.752 core:369] spotify: unexpected error happened error=HTTPError(404, 'Not Found',
HTTPResponse(_body=None,_error_is_response_code=True,buffer=<_io.BytesIO object at
0x75aeebf44ae0>,code=404,effective_url='http://repository.spotify.com//dists/testing/Release',error=HTTP 404: Not
Found,headers=<tornado.httputil.HTTPHeaders object at 0x75aeebabaed0>,reason='Not
Found',request=<tornado.httpclient.HTTPRequest object at
0x75aeec55bd90>,request_time=0.09214305877685547,start_time=1739432789.66019,time_info={'queue':
4.5299530029296875e-06, 'namelookup': 0.016925, 'connect': 0.021028, 'appconnect': 0.0, 'pretransfer': 0.021053,
'starttransfer': 0.091859, 'total': 0.091912, 'redirect': 0.0}))
[...]
```

Removing the trailing `/` from the mirror URL fixes it.