### PR TITLE
More elegant approach for nginx reloads

### DIFF
--- a/Ansible/roles/regenerate_ssl_certificate/tasks/main.yml
+++ b/Ansible/roles/regenerate_ssl_certificate/tasks/main.yml
@@ -114,15 +114,9 @@
 
 - name: "Reload nginx (if running)" # noqa: command-instead-of-module
   ansible.builtin.shell:
-    cmd: systemctl is-active --quiet nginx || exit 99; nginx -t && nginx -s reload
-  register: reload_nginx
-  changed_when: reload_nginx.rc == 0
-  failed_when: reload_nginx.rc not in [0, 99]
-
-- name: "Show errors when reload nginx (if there are)"
-  ansible.builtin.debug:
-    msg: "{{ reload_nginx.stderr_lines }}"
-  when: reload_nginx.stderr_lines | length > 0
+    cmd: systemctl try-reload-or-restart nginx
+  changed_when: true
+  when: inventory_hostname.startswith('web')
 
 - name: "Send confirmation mail"
   ansible.builtin.shell:


### PR DESCRIPTION
- Use `systemctl try-reload-or-restart` to only trigger a reload of the `nginx` service if it's already running (so only on the active cluster node):

<https://man7.org/linux/man-pages/man1/systemctl.1.html>

```text
try-reload-or-restart PATTERN...
    Reload one or more units if they support it. If not, stop and
    then start them instead. This does nothing if the units are
    not running.
```

- Drop explicit configuration validation (`nginx -t`), which is already done implicitly when running `nginx -s reload` (which is what the `ExecReload` property of the nginx systemd unit service file does):

```bash
$ systemctl show nginx.service --property=ExecReload
ExecReload={ path=/usr/bin/nginx ; argv[]=/usr/bin/nginx -s reload ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }
```

<https://nginx.org/en/docs/beginners_guide.html#control>

```text
 Changes made in the configuration file will not be applied until the command to reload configuration is sent to nginx or it is restarted. To reload configuration, execute:

    nginx -s reload

Once the master process receives the signal to reload configuration, it checks the syntax validity of the new configuration file and tries to apply the configuration provided in it. If this is a success, the master process starts new worker processes and sends messages to old worker processes, requesting them to shut down. Otherwise, the master process rolls back the changes and continues to work with the old configuration. Old worker processes, receiving a command to shut down, stop accepting new connections and continue to service current requests until all such requests are serviced. After that, the old worker processes exit.
```

- Only run on relevant hosts ("web" ones).

- Drop unnecessary stderr output (with this new approach)