### PR TITLE
Avoid potential partial upgrades with Arch Ansible tasks

### DIFF
--- a/Ansible/roles/add_package/tasks/main.yml
+++ b/Ansible/roles/add_package/tasks/main.yml
@@ -15,7 +15,6 @@
 
 - name: "Install package(s) - Arch"
   community.general.pacman:
-    update_cache: true
     name: "{{ package_arch }}"
     state: present
   when: ansible_facts['distribution'] == "Archlinux" and (package_arch is defined and package_arch | length > 0)

--- a/Ansible/roles/update_servers/tasks/alpine.yml
+++ b/Ansible/roles/update_servers/tasks/alpine.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Update repos"
+- name: "Update local repo DB"
   community.general.apk:
     update_cache: true
 

--- a/Ansible/roles/update_servers/tasks/arch.yml
+++ b/Ansible/roles/update_servers/tasks/arch.yml
@@ -1,8 +1,4 @@
 ---
-- name: "Update repos"
-  community.general.pacman:
-    update_cache: true
-
 - name: "Get packages to update"
   ansible.builtin.shell:
     cmd: checkupdates
@@ -17,6 +13,7 @@
 
 - name: "Update servers"
   community.general.pacman:
+    update_cache: true
     upgrade: true
 
 - name: "Get orphan packages"

--- a/Ansible/roles/update_servers/tasks/debian.yml
+++ b/Ansible/roles/update_servers/tasks/debian.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Update repos"
+- name: "Update local repo DB"
   ansible.builtin.apt:
     update_cache: true
 


### PR DESCRIPTION
- update_servers: checkupdats uses its own separate local DB. We don't need to update the pacman one beforehand, we can just do it from the upgrade task.
- add_package: updating the local DB with 'update_cache: true' when installing a package is effectively the same as 'pacman -Sy <pkg>'.

Also adopt a more precise name for the related task for Alpine and Debian while we're at it.